### PR TITLE
feat: Deep Jido ecosystem integration

### DIFF
--- a/lib/dingleberry/actions/approve_request.ex
+++ b/lib/dingleberry/actions/approve_request.ex
@@ -10,6 +10,9 @@ defmodule Dingleberry.Actions.ApproveRequest do
     schema: [
       request_id: [type: :string, required: true, doc: "The approval request ID"],
       decided_by: [type: :string, default: "human", doc: "Who made the decision"]
+    ],
+    output_schema: [
+      decision: [type: :map, required: true, doc: "The approval decision struct as a map"]
     ]
 
   alias Dingleberry.Approval.Queue

--- a/lib/dingleberry/actions/classify_command.ex
+++ b/lib/dingleberry/actions/classify_command.ex
@@ -10,9 +10,22 @@ defmodule Dingleberry.Actions.ClassifyCommand do
     schema: [
       command: [type: :string, required: true, doc: "The shell command to classify"],
       scope: [type: :atom, default: :shell, doc: "Classification scope (:shell, :mcp, :all)"]
+    ],
+    output_schema: [
+      risk: [type: :atom, required: true, doc: "Risk level (:safe, :warn, :block)"],
+      rule_name: [type: :string, doc: "Name of the matched policy rule"],
+      command: [type: :string, required: true, doc: "The original command"]
     ]
 
   alias Dingleberry.Policy.Engine, as: PolicyEngine
+
+  @impl true
+  def on_before_validate_params(params) do
+    case Map.get(params, :command) do
+      cmd when is_binary(cmd) -> {:ok, %{params | command: String.trim(cmd)}}
+      _ -> {:ok, params}
+    end
+  end
 
   @impl true
   def run(params, _context) do

--- a/lib/dingleberry/actions/classify_tool_call.ex
+++ b/lib/dingleberry/actions/classify_tool_call.ex
@@ -10,6 +10,11 @@ defmodule Dingleberry.Actions.ClassifyToolCall do
     schema: [
       name: [type: :string, required: true, doc: "The MCP tool name"],
       arguments: [type: :map, default: %{}, doc: "The tool call arguments"]
+    ],
+    output_schema: [
+      risk: [type: :atom, required: true, doc: "Risk level (:safe, :warn, :block)"],
+      rule_name: [type: :string, doc: "Name of the matched policy rule"],
+      description: [type: :string, required: true, doc: "Human-readable tool call description"]
     ]
 
   alias Dingleberry.Policy.Engine, as: PolicyEngine

--- a/lib/dingleberry/actions/reject_request.ex
+++ b/lib/dingleberry/actions/reject_request.ex
@@ -11,6 +11,9 @@ defmodule Dingleberry.Actions.RejectRequest do
       request_id: [type: :string, required: true, doc: "The approval request ID"],
       decided_by: [type: :string, default: "human", doc: "Who made the decision"],
       reason: [type: :string, doc: "Reason for rejection"]
+    ],
+    output_schema: [
+      decision: [type: :map, required: true, doc: "The rejection decision struct as a map"]
     ]
 
   alias Dingleberry.Approval.Queue

--- a/lib/dingleberry/signals/bus_config.ex
+++ b/lib/dingleberry/signals/bus_config.ex
@@ -18,6 +18,9 @@ defmodule Dingleberry.Signals.BusConfig do
   def child_spec(_opts \\ []) do
     Bus.child_spec(
       name: @bus_name,
+      journal_adapter: Jido.Signal.Journal.Adapters.ETS,
+      journal_adapter_opts: [],
+      max_log_size: 100_000,
       middleware: [
         {Dingleberry.Signals.Middleware.RiskClassifier, [log_classifications: true]},
         {Dingleberry.Signals.Middleware.AuditLogger, [log_safe: false]},

--- a/lib/dingleberry/signals/extensions/audit_context.ex
+++ b/lib/dingleberry/signals/extensions/audit_context.ex
@@ -1,0 +1,11 @@
+defmodule Dingleberry.Signals.Extensions.AuditContext do
+  @moduledoc "Signal extension for audit trail context."
+
+  use Jido.Signal.Ext,
+    namespace: "audit.context",
+    schema: [
+      session_id: [type: :string, doc: "MCP proxy session ID"],
+      hostname: [type: :string, doc: "Hostname where the command originated"],
+      request_id: [type: :string, doc: "Unique request correlation ID"]
+    ]
+end

--- a/lib/dingleberry/signals/extensions/decision_context.ex
+++ b/lib/dingleberry/signals/extensions/decision_context.ex
@@ -1,0 +1,10 @@
+defmodule Dingleberry.Signals.Extensions.DecisionContext do
+  @moduledoc "Signal extension for decision-making context."
+
+  use Jido.Signal.Ext,
+    namespace: "decision.context",
+    schema: [
+      decision_time_ms: [type: :non_neg_integer, doc: "Time taken to make decision in milliseconds"],
+      approver_id: [type: :string, doc: "Identifier of the person/system that made the decision"]
+    ]
+end

--- a/lib/dingleberry/signals/extensions/risk_metadata.ex
+++ b/lib/dingleberry/signals/extensions/risk_metadata.ex
@@ -1,0 +1,11 @@
+defmodule Dingleberry.Signals.Extensions.RiskMetadata do
+  @moduledoc "Signal extension for risk classification metadata."
+
+  use Jido.Signal.Ext,
+    namespace: "risk.metadata",
+    schema: [
+      risk_level: [type: :atom, required: true, doc: "Risk classification (:safe, :warn, :block)"],
+      risk_score: [type: :float, doc: "Numeric risk score (0.0 to 1.0)"],
+      classified_at: [type: :string, doc: "ISO 8601 timestamp of classification"]
+    ]
+end

--- a/lib/dingleberry/signals/middleware/audit_logger.ex
+++ b/lib/dingleberry/signals/middleware/audit_logger.ex
@@ -27,6 +27,19 @@ defmodule Dingleberry.Signals.Middleware.AuditLogger do
     {:cont, signals, %{state | signal_count: state.signal_count + length(signals)}}
   end
 
+  @impl true
+  def after_dispatch(signal, subscriber, result, _context, state) do
+    case result do
+      :ok ->
+        Logger.debug("AuditLogger: Dispatched #{signal.type} to subscriber #{inspect(subscriber.id)}")
+
+      {:error, reason} ->
+        Logger.warning("AuditLogger: Failed dispatching #{signal.type} to subscriber #{inspect(subscriber.id)}: #{inspect(reason)}")
+    end
+
+    {:cont, state}
+  end
+
   defp maybe_record(%{type: "dingleberry.command.decided"} = signal, _state) do
     data = signal.data
 

--- a/lib/dingleberry/signals/middleware/risk_classifier.ex
+++ b/lib/dingleberry/signals/middleware/risk_classifier.ex
@@ -29,6 +29,37 @@ defmodule Dingleberry.Signals.Middleware.RiskClassifier do
     {:cont, enriched, state}
   end
 
+  @impl true
+  def before_dispatch(signal, _subscriber, _context, state) do
+    if signal.type == "dingleberry.command.intercepted" do
+      risk = get_in(signal.data, [:risk]) || get_in(signal.data, ["risk"])
+
+      if risk do
+        risk_metadata = %{
+          risk_level: risk,
+          risk_score: risk_score(risk),
+          classified_at: DateTime.utc_now() |> DateTime.to_iso8601()
+        }
+
+        enriched = Map.update(signal, :extensions, %{"risk.metadata" => risk_metadata}, fn exts ->
+          Map.put(exts || %{}, "risk.metadata", risk_metadata)
+        end)
+
+        {:cont, enriched, state}
+      else
+        {:cont, signal, state}
+      end
+    else
+      {:cont, signal, state}
+    end
+  end
+
+  defp risk_score(:block), do: 1.0
+  defp risk_score("block"), do: 1.0
+  defp risk_score(:warn), do: 0.5
+  defp risk_score("warn"), do: 0.5
+  defp risk_score(_), do: 0.0
+
   defp enrich_with_risk(signal, state, _context) do
     risk = get_in(signal.data, [:risk]) || get_in(signal.data, ["risk"])
 

--- a/lib/dingleberry_web/controllers/api/tools_controller.ex
+++ b/lib/dingleberry_web/controllers/api/tools_controller.ex
@@ -1,0 +1,76 @@
+defmodule DingleberryWeb.API.ToolsController do
+  use DingleberryWeb, :controller
+
+  alias Dingleberry.Actions.{ClassifyCommand, ClassifyToolCall, ApproveRequest, RejectRequest, RecordAudit}
+
+  @actions %{
+    "classify_command" => ClassifyCommand,
+    "classify_tool_call" => ClassifyToolCall,
+    "approve_request" => ApproveRequest,
+    "reject_request" => RejectRequest,
+    "record_audit" => RecordAudit
+  }
+
+  @doc "GET /api/v1/tools — List all actions as LLM tool definitions"
+  def index(conn, _params) do
+    tools =
+      @actions
+      |> Enum.map(fn {_name, module} -> module.to_tool() end)
+      |> Enum.sort_by(& &1.name)
+
+    json(conn, %{tools: Enum.map(tools, &serialize_tool/1)})
+  end
+
+  @doc "GET /api/v1/tools/:name — Get a single tool definition"
+  def show(conn, %{"name" => name}) do
+    case Map.get(@actions, name) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Unknown tool: #{name}"})
+
+      module ->
+        tool = module.to_tool()
+        json(conn, %{tool: serialize_tool(tool)})
+    end
+  end
+
+  @doc "POST /api/v1/tools/:name/run — Execute a named tool via Jido.Exec"
+  def run(conn, %{"name" => name} = params) do
+    case Map.get(@actions, name) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Unknown tool: #{name}"})
+
+      module ->
+        tool_params =
+          params
+          |> Map.get("params", %{})
+          |> Jido.Action.Tool.convert_params_using_schema(module.schema())
+
+        case Jido.Exec.run(module, tool_params, %{}) do
+          {:ok, result} ->
+            json(conn, %{ok: true, result: result})
+
+          {:error, error} when is_exception(error) ->
+            conn
+            |> put_status(:unprocessable_entity)
+            |> json(%{ok: false, error: Exception.message(error)})
+
+          {:error, reason} ->
+            conn
+            |> put_status(:unprocessable_entity)
+            |> json(%{ok: false, error: inspect(reason)})
+        end
+    end
+  end
+
+  defp serialize_tool(tool) do
+    %{
+      name: tool.name,
+      description: tool.description,
+      parameters_schema: tool.parameters_schema
+    }
+  end
+end

--- a/lib/dingleberry_web/router.ex
+++ b/lib/dingleberry_web/router.ex
@@ -23,6 +23,15 @@ defmodule DingleberryWeb.Router do
     live "/sessions", SessionsLive, :index
   end
 
+  # LLM Tools API
+  scope "/api/v1", DingleberryWeb.API do
+    pipe_through :api
+
+    get "/tools", ToolsController, :index
+    get "/tools/:name", ToolsController, :show
+    post "/tools/:name/run", ToolsController, :run
+  end
+
   # MCP SSE/HTTP transport endpoints
   scope "/mcp" do
     pipe_through :api

--- a/test/dingleberry/actions/jido_features_test.exs
+++ b/test/dingleberry/actions/jido_features_test.exs
@@ -1,0 +1,208 @@
+defmodule Dingleberry.Actions.JidoFeaturesTest do
+  use Dingleberry.DataCase
+
+  alias Dingleberry.Actions.{
+    ClassifyCommand,
+    ClassifyToolCall,
+    ApproveRequest,
+    RejectRequest,
+    RecordAudit
+  }
+
+  describe "output_schema/0" do
+    test "ClassifyCommand has output_schema with risk, rule_name, command" do
+      schema = ClassifyCommand.output_schema()
+      assert Keyword.has_key?(schema, :risk)
+      assert Keyword.has_key?(schema, :rule_name)
+      assert Keyword.has_key?(schema, :command)
+      assert schema[:risk][:required] == true
+      assert schema[:command][:required] == true
+    end
+
+    test "ClassifyToolCall has output_schema with risk, rule_name, description" do
+      schema = ClassifyToolCall.output_schema()
+      assert Keyword.has_key?(schema, :risk)
+      assert Keyword.has_key?(schema, :rule_name)
+      assert Keyword.has_key?(schema, :description)
+      assert schema[:risk][:required] == true
+      assert schema[:description][:required] == true
+    end
+
+    test "ApproveRequest has output_schema with decision" do
+      schema = ApproveRequest.output_schema()
+      assert Keyword.has_key?(schema, :decision)
+      assert schema[:decision][:required] == true
+      assert schema[:decision][:type] == :map
+    end
+
+    test "RejectRequest has output_schema with decision" do
+      schema = RejectRequest.output_schema()
+      assert Keyword.has_key?(schema, :decision)
+      assert schema[:decision][:required] == true
+    end
+
+    test "RecordAudit has output_schema with entry_id" do
+      schema = RecordAudit.output_schema()
+      assert Keyword.has_key?(schema, :entry_id)
+      assert schema[:entry_id][:required] == true
+      assert schema[:entry_id][:type] == :integer
+    end
+
+    test "all actions have non-empty output_schema" do
+      for module <- [ClassifyCommand, ClassifyToolCall, ApproveRequest, RejectRequest, RecordAudit] do
+        schema = module.output_schema()
+        assert is_list(schema) and length(schema) > 0,
+               "#{inspect(module)} should have a non-empty output_schema"
+      end
+    end
+  end
+
+  describe "lifecycle hooks" do
+    test "ClassifyCommand.on_before_validate_params/1 trims command whitespace" do
+      {:ok, result} = ClassifyCommand.on_before_validate_params(%{command: "  ls -la  ", scope: :shell})
+      assert result.command == "ls -la"
+    end
+
+    test "ClassifyCommand.on_before_validate_params/1 handles non-string command" do
+      {:ok, result} = ClassifyCommand.on_before_validate_params(%{scope: :shell})
+      refute Map.has_key?(result, :command)
+    end
+
+    test "RecordAudit.on_after_run/1 passes through success" do
+      success = {:ok, %{entry_id: 42}}
+      assert RecordAudit.on_after_run(success) == success
+    end
+
+    test "RecordAudit.on_after_run/1 passes through error" do
+      error = {:error, :some_error}
+      assert RecordAudit.on_after_run(error) == error
+    end
+
+    test "RecordAudit.on_error/4 returns error tuple" do
+      result = RecordAudit.on_error(%{command: "test"}, :db_error, %{}, [])
+      assert {:error, :db_error} = result
+    end
+  end
+
+  describe "to_tool/0" do
+    test "ClassifyCommand generates a valid tool definition" do
+      tool = ClassifyCommand.to_tool()
+      assert tool.name == "classify_command"
+      assert is_binary(tool.description)
+      assert is_function(tool.function, 2)
+      assert is_map(tool.parameters_schema)
+      assert tool.parameters_schema["type"] == "object"
+      assert Map.has_key?(tool.parameters_schema["properties"], "command")
+    end
+
+    test "ClassifyToolCall generates a valid tool definition" do
+      tool = ClassifyToolCall.to_tool()
+      assert tool.name == "classify_tool_call"
+      assert Map.has_key?(tool.parameters_schema["properties"], "name")
+    end
+
+    test "ApproveRequest generates a valid tool definition" do
+      tool = ApproveRequest.to_tool()
+      assert tool.name == "approve_request"
+      assert Map.has_key?(tool.parameters_schema["properties"], "request_id")
+    end
+
+    test "RejectRequest generates a valid tool definition" do
+      tool = RejectRequest.to_tool()
+      assert tool.name == "reject_request"
+      assert Map.has_key?(tool.parameters_schema["properties"], "request_id")
+    end
+
+    test "RecordAudit generates a valid tool definition" do
+      tool = RecordAudit.to_tool()
+      assert tool.name == "record_audit"
+      assert Map.has_key?(tool.parameters_schema["properties"], "command")
+      assert Map.has_key?(tool.parameters_schema["properties"], "risk")
+    end
+
+    test "all tools have required fields in schema" do
+      for module <- [ClassifyCommand, ClassifyToolCall, ApproveRequest, RejectRequest, RecordAudit] do
+        tool = module.to_tool()
+        assert is_list(tool.parameters_schema["required"]),
+               "#{inspect(module)}.to_tool() should list required params"
+      end
+    end
+  end
+
+  describe "Jido.Exec.run/3 integration" do
+    test "executes ClassifyCommand via Exec with full validation" do
+      {:ok, result} = Jido.Exec.run(ClassifyCommand, %{command: "ls -la"}, %{})
+      assert result.risk == :safe
+      assert result.command == "ls -la"
+    end
+
+    test "executes ClassifyCommand with whitespace-trimmed command" do
+      {:ok, result} = Jido.Exec.run(ClassifyCommand, %{command: "  git status  "}, %{})
+      assert result.command == "git status"
+      assert result.risk == :safe
+    end
+
+    test "Exec validates output schema on ClassifyCommand" do
+      # Running through Exec applies output_schema validation
+      {:ok, result} = Jido.Exec.run(ClassifyCommand, %{command: "rm -rf /"}, %{})
+      assert is_atom(result.risk)
+      assert is_binary(result.command)
+    end
+
+    test "executes RecordAudit via Exec" do
+      # timeout: 0 avoids spawning a Task, keeping DB sandbox ownership
+      {:ok, result} =
+        Jido.Exec.run(RecordAudit, %{
+          command: "test_exec_cmd",
+          risk: "safe",
+          decision: "auto_approved",
+          source: "test"
+        }, %{}, timeout: 0)
+
+      assert is_integer(result.entry_id)
+    end
+  end
+
+  describe "validate_params/1" do
+    test "ClassifyCommand validates required command field" do
+      assert {:error, _} = ClassifyCommand.validate_params(%{})
+    end
+
+    test "ClassifyCommand accepts valid params" do
+      assert {:ok, params} = ClassifyCommand.validate_params(%{command: "ls", scope: :shell})
+      assert params.command == "ls"
+    end
+
+    test "RecordAudit validates required fields" do
+      assert {:error, _} = RecordAudit.validate_params(%{command: "test"})
+    end
+
+    test "RecordAudit accepts valid params" do
+      assert {:ok, _} =
+               RecordAudit.validate_params(%{
+                 command: "test",
+                 risk: "safe",
+                 decision: "approved"
+               })
+    end
+  end
+
+  describe "validate_output/1" do
+    test "ClassifyCommand validates output with required fields" do
+      assert {:ok, _} =
+               ClassifyCommand.validate_output(%{risk: :safe, command: "ls", rule_name: "safe_cmd"})
+    end
+
+    test "ClassifyCommand rejects output missing required field" do
+      assert {:error, _} = ClassifyCommand.validate_output(%{rule_name: "test"})
+    end
+
+    test "RecordAudit validates output" do
+      assert {:ok, _} = RecordAudit.validate_output(%{entry_id: 1})
+    end
+
+    test "RecordAudit rejects output missing entry_id" do
+      assert {:error, _} = RecordAudit.validate_output(%{})
+    end
+  end
+end

--- a/test/dingleberry/signals/extensions_test.exs
+++ b/test/dingleberry/signals/extensions_test.exs
@@ -1,0 +1,113 @@
+defmodule Dingleberry.Signals.ExtensionsTest do
+  use ExUnit.Case
+
+  alias Dingleberry.Signals.Extensions.{RiskMetadata, AuditContext, DecisionContext}
+
+  describe "RiskMetadata extension" do
+    test "has correct namespace" do
+      assert RiskMetadata.namespace() == "risk.metadata"
+    end
+
+    test "has schema with risk_level, risk_score, classified_at" do
+      schema = RiskMetadata.schema()
+      assert Keyword.has_key?(schema, :risk_level)
+      assert Keyword.has_key?(schema, :risk_score)
+      assert Keyword.has_key?(schema, :classified_at)
+    end
+
+    test "validates data with required risk_level" do
+      assert {:ok, validated} =
+               RiskMetadata.validate_data(%{
+                 risk_level: :warn,
+                 risk_score: 0.5,
+                 classified_at: "2026-02-27T00:00:00Z"
+               })
+
+      assert validated.risk_level == :warn
+      assert validated.risk_score == 0.5
+    end
+
+    test "rejects data missing required risk_level" do
+      assert {:error, _reason} =
+               RiskMetadata.validate_data(%{risk_score: 0.5})
+    end
+
+    test "accepts data with only required fields" do
+      assert {:ok, validated} = RiskMetadata.validate_data(%{risk_level: :safe})
+      assert validated.risk_level == :safe
+    end
+  end
+
+  describe "AuditContext extension" do
+    test "has correct namespace" do
+      assert AuditContext.namespace() == "audit.context"
+    end
+
+    test "has schema with session_id, hostname, request_id" do
+      schema = AuditContext.schema()
+      assert Keyword.has_key?(schema, :session_id)
+      assert Keyword.has_key?(schema, :hostname)
+      assert Keyword.has_key?(schema, :request_id)
+    end
+
+    test "validates data with all fields" do
+      assert {:ok, validated} =
+               AuditContext.validate_data(%{
+                 session_id: "sess-123",
+                 hostname: "localhost",
+                 request_id: "req-456"
+               })
+
+      assert validated.session_id == "sess-123"
+      assert validated.hostname == "localhost"
+    end
+
+    test "validates data with no fields (all optional)" do
+      assert {:ok, _validated} = AuditContext.validate_data(%{})
+    end
+  end
+
+  describe "DecisionContext extension" do
+    test "has correct namespace" do
+      assert DecisionContext.namespace() == "decision.context"
+    end
+
+    test "has schema with decision_time_ms, approver_id" do
+      schema = DecisionContext.schema()
+      assert Keyword.has_key?(schema, :decision_time_ms)
+      assert Keyword.has_key?(schema, :approver_id)
+    end
+
+    test "validates data with all fields" do
+      assert {:ok, validated} =
+               DecisionContext.validate_data(%{
+                 decision_time_ms: 1500,
+                 approver_id: "user-789"
+               })
+
+      assert validated.decision_time_ms == 1500
+      assert validated.approver_id == "user-789"
+    end
+
+    test "validates data with no fields (all optional)" do
+      assert {:ok, _validated} = DecisionContext.validate_data(%{})
+    end
+
+    test "rejects negative decision_time_ms" do
+      assert {:error, _reason} =
+               DecisionContext.validate_data(%{decision_time_ms: -1})
+    end
+  end
+
+  describe "extension callbacks" do
+    test "to_attrs/1 returns data unchanged by default" do
+      data = %{risk_level: :warn, risk_score: 0.5}
+      assert RiskMetadata.to_attrs(data) == data
+    end
+
+    test "from_attrs/1 returns data unchanged by default" do
+      attrs = %{session_id: "test", hostname: "local"}
+      assert AuditContext.from_attrs(attrs) == attrs
+    end
+  end
+end

--- a/test/dingleberry_web/controllers/api/tools_controller_test.exs
+++ b/test/dingleberry_web/controllers/api/tools_controller_test.exs
@@ -1,0 +1,101 @@
+defmodule DingleberryWeb.API.ToolsControllerTest do
+  use DingleberryWeb.ConnCase
+
+  describe "GET /api/v1/tools" do
+    test "lists all 5 tool definitions", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/tools")
+      assert %{"tools" => tools} = json_response(conn, 200)
+      assert length(tools) == 5
+
+      names = Enum.map(tools, & &1["name"])
+      assert "classify_command" in names
+      assert "classify_tool_call" in names
+      assert "approve_request" in names
+      assert "reject_request" in names
+      assert "record_audit" in names
+    end
+
+    test "tools are sorted by name", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/tools")
+      %{"tools" => tools} = json_response(conn, 200)
+      names = Enum.map(tools, & &1["name"])
+      assert names == Enum.sort(names)
+    end
+
+    test "each tool has name, description, and parameters_schema", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/tools")
+      %{"tools" => tools} = json_response(conn, 200)
+
+      for tool <- tools do
+        assert is_binary(tool["name"]), "tool should have a name"
+        assert is_binary(tool["description"]), "tool should have a description"
+        assert is_map(tool["parameters_schema"]), "tool should have parameters_schema"
+        assert tool["parameters_schema"]["type"] == "object"
+      end
+    end
+  end
+
+  describe "GET /api/v1/tools/:name" do
+    test "returns a single tool definition", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/tools/classify_command")
+      assert %{"tool" => tool} = json_response(conn, 200)
+      assert tool["name"] == "classify_command"
+      assert is_binary(tool["description"])
+      assert is_map(tool["parameters_schema"])
+    end
+
+    test "returns 404 for unknown tool", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/tools/nonexistent_tool")
+      assert %{"error" => error} = json_response(conn, 404)
+      assert error =~ "Unknown tool"
+    end
+  end
+
+  describe "POST /api/v1/tools/:name/run" do
+    test "executes classify_command tool successfully", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/v1/tools/classify_command/run", %{
+          "params" => %{"command" => "ls -la"}
+        })
+
+      assert %{"ok" => true, "result" => result} = json_response(conn, 200)
+      assert result["command"] == "ls -la"
+      assert result["risk"] == "safe"
+    end
+
+    test "executes record_audit tool successfully", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/v1/tools/record_audit/run", %{
+          "params" => %{
+            "command" => "test_api_cmd",
+            "risk" => "safe",
+            "decision" => "auto_approved",
+            "source" => "api_test"
+          }
+        })
+
+      assert %{"ok" => true, "result" => result} = json_response(conn, 200)
+      assert is_integer(result["entry_id"])
+    end
+
+    test "returns 404 for unknown tool", %{conn: conn} do
+      conn = post(conn, ~p"/api/v1/tools/nonexistent/run", %{"params" => %{}})
+      assert %{"error" => _} = json_response(conn, 404)
+    end
+
+    test "returns 422 when params are invalid", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/v1/tools/record_audit/run", %{
+          "params" => %{"command" => "test"}
+        })
+
+      assert %{"ok" => false, "error" => _} = json_response(conn, 422)
+    end
+
+    test "uses default empty params when none provided", %{conn: conn} do
+      conn = post(conn, ~p"/api/v1/tools/classify_command/run", %{})
+      # Should fail validation since command is required
+      assert %{"ok" => false, "error" => _} = json_response(conn, 422)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Upgrades Dingleberry from ~30% to **full leverage** of the Jido ecosystem (jido_action 2.0, jido_signal 2.0). This is the project's first PR and demonstrates Dingleberry as a first-class Jido-powered application.

### Actions (jido_action) — Full Feature Usage
- **Output schemas** on all 5 actions — validates return values, enforces contracts
- **Lifecycle hooks**: `on_before_validate_params` (ClassifyCommand trims whitespace), `on_after_run` + `on_error` (RecordAudit logs success/failure)
- **Compensation** enabled on RecordAudit (max_retries: 2, timeout: 5000)
- **`to_tool()`** generates OpenAI/Claude function-calling definitions for all 5 actions

### Signal Extensions (jido_signal) — Full Feature Usage
- **3 Signal Extensions** via `Jido.Signal.Ext`: `RiskMetadata`, `AuditContext`, `DecisionContext`
- **ETS Journal** enabled on the signal bus for persistence and replay
- **Dispatch callbacks**: `before_dispatch` on RiskClassifier (attaches risk metadata extension), `after_dispatch` on AuditLogger (logs per-subscriber results)
- **Audit context** automatically attached to intercepted/decided signals

### LLM Tools API (new)
- `GET /api/v1/tools` — lists all actions as tool schemas
- `GET /api/v1/tools/:name` — single tool definition
- `POST /api/v1/tools/:name/run` — executes via `Jido.Exec.run` with full validation

### Stats
- **726 lines added** across 18 files (6 new, 12 modified)
- **55 new tests** (135 total), all passing
- `mix compile --warnings-as-errors` — clean

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 135 tests, 0 failures
- [x] `ClassifyCommand.to_tool()` generates valid tool definition
- [x] `ClassifyCommand.output_schema()` returns schema
- [x] Signal extensions validate data correctly
- [x] API endpoints return tool definitions and execute actions
- [ ] Manual smoke test: `curl localhost:4000/api/v1/tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)